### PR TITLE
Fixed bug with unevenly spaced input

### DIFF
--- a/pypret/mesh_data.py
+++ b/pypret/mesh_data.py
@@ -161,6 +161,8 @@ class MeshData(io.IO):
                     uncertainty = np.take(uncertainty, idx, axis=i)
         dataf = RegularGridInterpolator(tuple(orig_axes), data,
                                         bounds_error=False, fill_value=0.0)
+        # Resample the axes to be evenly spaced
+        axes = [np.linspace(axis[0],axis[-1],len(axis),endpoint=True) for axis in axes]
         grid = lib.build_coords(*axes)
         self.data = dataf(grid)
         self.axes = axes

--- a/pypret/retrieval/retriever.py
+++ b/pypret/retrieval/retriever.py
@@ -7,6 +7,7 @@ from ..mesh_data import MeshData
 from ..pulse_error import pulse_error
 from .. import lib
 from ..pnps import BasePNPS
+from math import isclose
 
 # global dictionary that contains all PNPS classes
 _RETRIEVER_CLASSES = {}
@@ -106,7 +107,7 @@ class BaseRetriever(io.IO, metaclass=MetaIORetriever):
 
     def _retrieve_begin(self, measurement, initial_guess, weights):
         pnps = self.pnps
-        if not np.all(pnps.process_w == measurement.axes[1]):
+        if not np.allclose(pnps.process_w, measurement.axes[1], rtol=1e-6):
             raise ValueError("Measurement has to lie on simulation grid!")
         # Store measurement
         self.measurement = measurement


### PR DESCRIPTION
Changed exact equality check for measurement frequencies being the same as pnps frequencies to approximate equality, and changed the MeshGrid.interpolate() function so that it updates the axes as well as the data, like one would expect.